### PR TITLE
New: Add `already` event for modules which were already required

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,12 @@ EventedRequire.prototype.require = function(moduleName) {
     opts.basedir = this._basedir;
   }
 
-  var result, already, modulePath;
+  var result, exists, modulePath;
   this.emit('before', moduleName);
   try {
     modulePath = resolve.sync(moduleName, opts);
     if (require.cache[modulePath]) {
-      already = true;
+      exists = true;
     }
     result = require(modulePath);
   } catch (e) {
@@ -39,8 +39,8 @@ EventedRequire.prototype.require = function(moduleName) {
     return null;
   }
 
-  if (already) {
-    this.emit('already', moduleName, modulePath);
+  if (exists) {
+    this.emit('exists', moduleName, modulePath);
   } else {
     this.emit('success', moduleName, result);
   }

--- a/test/fixtures/baz.js
+++ b/test/fixtures/baz.js
@@ -1,0 +1,1 @@
+module.exports = 'baz';

--- a/test/fixtures/corge.js
+++ b/test/fixtures/corge.js
@@ -1,0 +1,1 @@
+module.exports = 'corge';

--- a/test/fixtures/fred.js
+++ b/test/fixtures/fred.js
@@ -1,0 +1,1 @@
+module.exports = 'fred';

--- a/test/fixtures/garply.js
+++ b/test/fixtures/garply.js
@@ -1,0 +1,1 @@
+module.exports = 'garply';

--- a/test/fixtures/grault.js
+++ b/test/fixtures/grault.js
@@ -1,0 +1,1 @@
+module.exports = 'grault';

--- a/test/fixtures/quux.js
+++ b/test/fixtures/quux.js
@@ -1,0 +1,1 @@
+module.exports = 'quux';

--- a/test/fixtures/qux.js
+++ b/test/fixtures/qux.js
@@ -1,0 +1,1 @@
+module.exports = 'qux';

--- a/test/fixtures/waldo.js
+++ b/test/fixtures/waldo.js
@@ -1,0 +1,1 @@
+module.exports = 'waldo';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -122,12 +122,12 @@ describe('evented-require', function() {
     done();
   });
 
-  it('emits a `already` event when the module was already loaded', function(done) {
+  it('emits a `exists` event when the module was already required', function(done) {
     var ee = new EventedRequire(__dirname);
 
     var spy = expect.createSpy();
 
-    ee.on('already', spy);
+    ee.on('exists', spy);
 
     var result = ee.require('./fixtures/foo.js');
 
@@ -273,7 +273,7 @@ describe('evented-require', function() {
     var spyAlready = expect.createSpy();
 
     ee.on('success', spySuccess);
-    ee.on('already', spyAlready);
+    ee.on('exists', spyAlready);
 
     var moduleNames = [
       './fixtures/fred.js',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var expect = require('expect');
-
+var path = require('path');
 var EventedRequire = require('../');
 
 describe('evented-require', function() {
@@ -36,9 +36,19 @@ describe('evented-require', function() {
   it('resolves from a basedir it is constructed with', function(done) {
     var ee = new EventedRequire(__dirname);
 
-    var result = ee.require('./fixtures/foo.js');
+    var result = ee.require('./fixtures/bar.js');
 
-    expect(result).toEqual('foo');
+    expect(result).toEqual('bar');
+
+    done();
+  });
+
+  it('require a module even if it was already required', function(done) {
+    var ee = new EventedRequire(__dirname);
+
+    var result = ee.require('./fixtures/bar.js');
+
+    expect(result).toEqual('bar');
 
     done();
   });
@@ -50,10 +60,29 @@ describe('evented-require', function() {
 
     ee.on('before', spy);
 
-    ee.require('./fixtures/foo.js');
+    var result = ee.require('./fixtures/baz.js');
+
+    expect(result).toEqual('baz');
 
     expect(spy.calls.length).toEqual(1);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js']);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/baz.js']);
+
+    done();
+  });
+
+  it('emits a `before` event even if the module was already required', function(done) {
+    var ee = new EventedRequire(__dirname);
+
+    var spy = expect.createSpy();
+
+    ee.on('before', spy);
+
+    var result = ee.require('./fixtures/baz.js');
+
+    expect(result).toEqual('baz');
+
+    expect(spy.calls.length).toEqual(1);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/baz.js']);
 
     done();
   });
@@ -65,10 +94,12 @@ describe('evented-require', function() {
 
     ee.on('success', spy);
 
-    ee.require('./fixtures/foo.js');
+    var result = ee.require('./fixtures/qux.js');
+
+    expect(result).toEqual('qux');
 
     expect(spy.calls.length).toEqual(1);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js', 'foo']);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/qux.js', 'qux']);
 
     done();
   });
@@ -80,11 +111,31 @@ describe('evented-require', function() {
 
     ee.on('failure', spy);
 
-    ee.require('./fixtures/no-exist.js');
+    var result = ee.require('./fixtures/no-exist.js');
+
+    expect(result).toEqual(null);
 
     expect(spy.calls.length).toEqual(1);
     expect(spy.calls[0].arguments[0]).toEqual('./fixtures/no-exist.js');
     expect(spy.calls[0].arguments[1]).toBeAn(Error);
+
+    done();
+  });
+
+  it('emits a `already` event when the module was already loaded', function(done) {
+    var ee = new EventedRequire(__dirname);
+
+    var spy = expect.createSpy();
+
+    ee.on('already', spy);
+
+    var result = ee.require('./fixtures/foo.js');
+
+    expect(result).toEqual('foo');
+
+    expect(spy.calls.length).toEqual(1);
+    expect(spy.calls[0].arguments[0]).toEqual('./fixtures/foo.js');
+    expect(spy.calls[0].arguments[1]).toEqual(path.resolve(__dirname, './fixtures/foo.js'));
 
     done();
   });
@@ -121,7 +172,7 @@ describe('evented-require', function() {
     ee.on('failure', spy);
 
     expect(function() {
-      ee.require('./fixtures/foo.js');
+      ee.require('./fixtures/quux.js');
     }).toThrow('boom');
 
     expect(spy.calls.length).toEqual(0);
@@ -158,10 +209,10 @@ describe('evented-require', function() {
 
     ee.on('success', spy);
 
-    r('./fixtures/foo.js');
+    r('./fixtures/corge.js');
 
     expect(spy.calls.length).toEqual(1);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js', 'foo']);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/corge.js', 'corge']);
 
     done();
   });
@@ -175,10 +226,10 @@ describe('evented-require', function() {
 
     ee.on('success', spy);
 
-    ra(['./fixtures/foo.js']);
+    ra(['./fixtures/grault.js']);
 
     expect(spy.calls.length).toEqual(1);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js', 'foo']);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/grault.js', 'grault']);
 
     done();
   });
@@ -200,11 +251,17 @@ describe('evented-require', function() {
 
     ee.on('success', spy);
 
-    ee.requireAll(['./fixtures/foo.js', './fixtures/bar.js']);
+    var results = ee.requireAll([
+      './fixtures/garply.js',
+      './fixtures/waldo.js',
+    ]);
+
+    expect(results['./fixtures/garply.js'], 'garply');
+    expect(results['./fixtures/waldo.js'], 'waldo');
 
     expect(spy.calls.length).toEqual(2);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js', 'foo']);
-    expect(spy.calls[1].arguments).toEqual(['./fixtures/bar.js', 'bar']);
+    expect(spy.calls[0].arguments).toEqual(['./fixtures/garply.js', 'garply']);
+    expect(spy.calls[1].arguments).toEqual(['./fixtures/waldo.js', 'waldo']);
 
     done();
   });
@@ -212,15 +269,41 @@ describe('evented-require', function() {
   it('only attempts to load a duplicate module once with requireAll', function(done) {
     var ee = new EventedRequire(__dirname);
 
-    var spy = expect.createSpy();
+    var spySuccess = expect.createSpy();
+    var spyAlready = expect.createSpy();
 
-    ee.on('success', spy);
+    ee.on('success', spySuccess);
+    ee.on('already', spyAlready);
 
-    ee.requireAll(['./fixtures/foo.js', './fixtures/bar.js', './fixtures/foo.js']);
+    var moduleNames = [
+      './fixtures/fred.js',
+      './fixtures/bar.js',
+      './fixtures/fred.js',
+      'eslint',
+      '../node_modules/eslint/lib/api.js',
+      '../node_modules/expect/lib',
+      'expect',
+    ];
+    var modules = ee.requireAll(moduleNames);
 
-    expect(spy.calls.length).toEqual(2);
-    expect(spy.calls[0].arguments).toEqual(['./fixtures/foo.js', 'foo']);
-    expect(spy.calls[1].arguments).toEqual(['./fixtures/bar.js', 'bar']);
+    expect(modules[moduleNames[0]]).toEqual('fred');
+    expect(modules[moduleNames[1]]).toEqual('bar');
+    expect(modules[moduleNames[2]]).toEqual('fred');
+    expect(modules[moduleNames[3]]).toNotEqual(null);
+    expect(modules[moduleNames[3]]).toEqual(modules[moduleNames[4]]);
+    expect(modules[moduleNames[5]]).toNotEqual(null);
+    expect(modules[moduleNames[5]]).toEqual(modules[moduleNames[6]]);
+
+    expect(spySuccess.calls.length).toEqual(2);
+    expect(spySuccess.calls[0].arguments).toEqual([moduleNames[0], modules[moduleNames[0]]]);
+    expect(spySuccess.calls[1].arguments).toEqual([moduleNames[3], modules[moduleNames[3]]]);
+
+    expect(spyAlready.calls.length).toEqual(5);
+    expect(spyAlready.calls[0].arguments).toEqual([moduleNames[1], path.resolve(__dirname, moduleNames[1])]);
+    expect(spyAlready.calls[1].arguments).toEqual([moduleNames[2], path.resolve(__dirname, moduleNames[0])]);
+    expect(spyAlready.calls[2].arguments).toEqual([moduleNames[4], path.resolve(__dirname, moduleNames[4])]);
+    expect(spyAlready.calls[3].arguments).toEqual([moduleNames[5], path.resolve(__dirname, moduleNames[5], 'index.js')]);
+    expect(spyAlready.calls[4].arguments).toEqual([moduleNames[6], path.resolve(__dirname, moduleNames[5], 'index.js')]);
 
     done();
   });


### PR DESCRIPTION
This pr is also a fix for the issue #2.

I also changed the return of `requireAll` to enable to require modules by id like following:

```js
const er = new EventedRequire()
const { foo, bar } = er.requireAll(['foo', 'bar'])
```